### PR TITLE
Remove EOL character when parsing Packages file

### DIFF
--- a/apt_mirror_check.py
+++ b/apt_mirror_check.py
@@ -61,7 +61,8 @@ def pkg_attrs(pkg_desc_path):
         attrs = {}
         last_key = None
         for line in f.readlines():
-            if len(line.strip()) == 0:
+            line = line.strip()
+            if len(line) == 0:
                 yield attrs
                 attrs = {}
                 last_key = None

--- a/apt_mirror_check.py
+++ b/apt_mirror_check.py
@@ -61,8 +61,8 @@ def pkg_attrs(pkg_desc_path):
         attrs = {}
         last_key = None
         for line in f.readlines():
-            line = line.strip()
-            if len(line) == 0:
+            line = line.rstrip('\n')
+            if len(line.strip()) == 0:
                 yield attrs
                 attrs = {}
                 last_key = None


### PR DESCRIPTION
Without it none of deb-files will be checked since all `attrs` keys have '\n' character at the end