### PR TITLE
Fix 'RuntimeError: generator raised StopIteration' on Python 3.7 and …

### DIFF
--- a/apt_mirror_check.py
+++ b/apt_mirror_check.py
@@ -144,7 +144,10 @@ def bad_files_in_dir(dirpath, attrs):
 def bad_files_in_mirror(mirror_dir):
     dist_root = os.path.join(mirror_dir, "dists")
     walker = os.walk(dist_root)
-    _, subdirs, _ = next(walker)
+    try:
+        _, subdirs, _ = next(walker)
+    except StopIteration:
+        subdirs = list()
 
     dist_dirs = [os.path.join(dist_root, subdir) for subdir in subdirs]
     pool_dir = os.path.join(mirror_dir, "pool")


### PR DESCRIPTION
This fixes the crash caused by [PEP479 - 'Change StopIteration handling inside generators'](https://peps.python.org/pep-0479/)

As of Python 3.7, when a StopIteration is raised inside a generator, it triggers a RuntimeError, crashing apt-mirror-check. This commit fixes that by quietly catching the StopIteration before it can propagate.