### PR TITLE
Flat repo handling, SHA512 and InRelease checking

### DIFF
--- a/apt_mirror_check.py
+++ b/apt_mirror_check.py
@@ -284,7 +284,7 @@ def get_sites_dir(base_dir):
 @click.option("-b", "--base-dir", type=click.Path(exists=True, file_okay=False, readable=True, resolve_path=True),
               help="apt-mirror base_path")
 @click.option("--delete/--no-delete", is_flag=True, default=False, help="delete corrupted files")
-@click.option("--all-package-check", is_flag=True, default=False, help="do not check .deb files (good for large mirrors)")
+@click.option("--all-package-check", is_flag=True, default=False, help="check all the .deb packages (not just newely synced)")
 def cli(base_dir, delete, all_package_check):
     sites_dir = get_sites_dir(base_dir)
 

--- a/apt_mirror_check.py
+++ b/apt_mirror_check.py
@@ -86,7 +86,6 @@ def pkg_attrs(pkg_desc_path):
 def pool_attrs(dist_dir, pool_dir):
     """ Parse attributes in Packages file"""
     attrs = {}
-    pool_parent_dir = os.path.dirname(pool_dir)
 
     for root, _, files in os.walk(dist_dir):
         for filename in files:

--- a/apt_mirror_check.py
+++ b/apt_mirror_check.py
@@ -166,15 +166,15 @@ def compare_in_release(release_path):
     inrelease_path = release_path.replace("Release", "InRelease")
     try:
         with open(release_path) as f:
-            release_lines = f.read().splitlines()
+            release_lines = [line for line in f.read().splitlines() if line.strip()]
         with open(inrelease_path) as f:
-            inrelease_lines = f.read().splitlines()
+            inrelease_lines = [line for line in f.read().splitlines() if line.strip()]
     except FileNotFoundError:
         return
     start_idx, stop_idx = 0, 0
     for i, line in enumerate(inrelease_lines):
         if line.strip() == "-----BEGIN PGP SIGNED MESSAGE-----":
-            start_idx = i + 3
+            start_idx = i + 2
         if line.strip() == "-----BEGIN PGP SIGNATURE-----":
             stop_idx = i
     if release_lines != inrelease_lines[start_idx:stop_idx]:


### PR DESCRIPTION
Hello

I've made some new features:
- handling of Flat Repos, see here: https://wiki.debian.org/DebianRepository/Format#Flat_Repository_Format
- added comparing InRelease to Release file (to ensure if InRelease have or have not been upgrade, workaround for 10y issue: https://github.com/apt-mirror/apt-mirror/issues/45)
- and added SHA512 checksum as a third hash algo